### PR TITLE
feat: ClientOnly component

### DIFF
--- a/vike-solid/components/ClientOnly.tsx
+++ b/vike-solid/components/ClientOnly.tsx
@@ -1,0 +1,36 @@
+import type { Component, JSX } from "solid-js";
+import { createEffect, createSignal, lazy, Suspense } from "solid-js";
+import { Dynamic } from "solid-js/web";
+
+function ClientOnlyError() {
+  return <p>Error loading component.</p>
+}
+
+export function ClientOnly<T>(props: {
+  load: () => Promise<{ default: Component<T> } | Component<T>>
+  children: (Component: Component<T>) => JSX.Element
+  fallback: JSX.Element
+  deps?: Parameters<typeof createSignal>[1]
+}) {
+  const [getComponent, setComponent] = createSignal<Component<unknown> | undefined>(undefined);
+
+  createEffect(() => {
+    const loadComponent = () => {
+      const Component = lazy(() =>
+        props.load()
+          .then((LoadedComponent) => {
+            return { default: () => props.children("default" in LoadedComponent ? LoadedComponent.default : LoadedComponent) };
+          })
+          .catch((error) => {
+            console.error("Component loading failed:", error);
+            return { default: ClientOnlyError };
+          })
+      );
+      setComponent(() => Component);
+    };
+
+    loadComponent();
+  });
+
+  return <Suspense fallback={props.fallback}><Dynamic component={getComponent()} /></Suspense>;
+}

--- a/vike-solid/package.json
+++ b/vike-solid/package.json
@@ -2,13 +2,6 @@
   "name": "vike-solid",
   "version": "0.2.5",
   "type": "module",
-  "exports": {
-    ".": "./dist/+config.js",
-    "./vite": "./dist/vite-plugin-vike-solid.js",
-    "./usePageContext": "./dist/usePageContext.js",
-    "./renderer/onRenderHtml": "./dist/+onRenderHtml.js",
-    "./renderer/onRenderClient": "./dist/+onRenderClient.js"
-  },
   "scripts": {
     "dev": "rollup -c rollup.config.js --watch",
     "build": "tsc --noEmit && rollup -c rollup.config.js",
@@ -39,6 +32,14 @@
     "vite": "^4.5.0",
     "vike": "^0.4.147"
   },
+  "exports": {
+    ".": "./dist/+config.js",
+    "./vite": "./dist/vite-plugin-vike-solid.js",
+    "./usePageContext": "./dist/usePageContext.js",
+    "./ClientOnly": "./dist/ClientOnly.js",
+    "./renderer/onRenderHtml": "./dist/+onRenderHtml.js",
+    "./renderer/onRenderClient": "./dist/+onRenderClient.js"
+  },
   "typesVersions": {
     "*": {
       ".": [
@@ -52,6 +53,9 @@
       ],
       "usePageContext": [
         "dist/components/usePageContext.d.ts"
+      ],
+      "ClientOnly": [
+        "dist/components/ClientOnly.d.ts"
       ]
     }
   },

--- a/vike-solid/rollup.config.js
+++ b/vike-solid/rollup.config.js
@@ -8,6 +8,7 @@ export default [
       "./renderer/+onRenderHtml.tsx",
       "./renderer/+config.ts",
       "./components/usePageContext.tsx",
+      "./components/ClientOnly.tsx",
       "./cli/index.ts",
     ],
     ssr: true,
@@ -26,6 +27,7 @@ export default [
     input: [
       "./renderer/+config.ts",
       "./components/usePageContext.tsx",
+      "./components/ClientOnly.tsx",
       "./vite-plugin-vike-solid.ts",
     ],
     output: [{ dir: "dist", format: "es", sanitizeFileName: false }],


### PR DESCRIPTION
Same as https://github.com/vikejs/vike-react/pull/35 but for Solid.

Closes #36

### Usage

```tsx
import { createSignal } from "solid-js";
import { ClientOnly } from "vike-solid/ClientOnly";

export { Counter };

function Counter() {
  const [count, setCount] = createSignal(0);

  return (
    <>
      <button onClick={() => setCount((count) => count + 1)}>
        Counter {count()}
      </button>
      <ClientOnly load={() => import('../star-wars/index/+Page')}>
        {(Page) => <Page movies={[{ id: '1', title: `${count()}`, release_date: 'today' }]} />}
      </ClientOnly>
    </>
  );
}

```