### PR TITLE
feat: add support for checking crawlers/bots & integrate renderToStringAsync()

### DIFF
--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "node-fetch": "^3.3.2",
     "solid-js": "^1.8.21",
-    "vike": "^0.4.191",
+    "vike": "^0.4.195",
     "vike-solid": "workspace:*"
   },
   "devDependencies": {

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "solid-js": "^1.8.21",
-    "vike": "^0.4.191",
+    "vike": "^0.4.195",
     "vike-solid": "workspace:*"
   },
   "devDependencies": {

--- a/examples/solid-query/.test-dev.test.ts
+++ b/examples/solid-query/.test-dev.test.ts
@@ -1,0 +1,2 @@
+import { testRun } from "./.testRun";
+testRun("pnpm run dev");

--- a/examples/solid-query/.test-preview.test.ts
+++ b/examples/solid-query/.test-preview.test.ts
@@ -1,0 +1,2 @@
+import { testRun } from "./.testRun";
+testRun("pnpm run preview");

--- a/examples/solid-query/.testRun.ts
+++ b/examples/solid-query/.testRun.ts
@@ -1,0 +1,70 @@
+export { testRun };
+
+import { test, expect, run, page, partRegex, getServerUrl, autoRetry } from "@brillout/test-e2e";
+const dataHk = partRegex`data-hk=${/[0-9-]+/}`;
+
+function testRun(cmd: `pnpm run ${"dev" | "preview"}`) {
+  run(cmd);
+
+  const content = "Return of the Jedi";
+  const loading = "Loading movies...";
+  const titleDefault = "My Vike + Solid App";
+  const titleOverriden = "6 Star Wars movies";
+  const titleAsScript = `<script>document.title = "${titleOverriden}"</script>`;
+  const description = partRegex`<meta ${dataHk} name="description" content="List of 6 Star Wars movies.">`;
+  test("HTML (as user)", async () => {
+    const html = await fetchAsUser("/");
+    expect(html).toContain(content);
+    expect(html).toContain(loading);
+    expect(html).toContain(titleAsScript);
+    expect(getTitle(html)).toBe(titleDefault);
+    expect(html.split("<title>").length).toBe(2);
+    expect(html).not.toMatch(description);
+  });
+  test("HTML (as bot)", async () => {
+    const html = await fetchAsBot("/");
+    expect(html).toContain(content);
+    expect(html).not.toContain(loading);
+    expect(html).not.toContain(titleAsScript);
+    expect(getTitle(html)).toBe(titleOverriden);
+    expect(html.split("<title>").length).toBe(2);
+    expect(html).toMatch(description);
+  });
+  test("DOM", async () => {
+    await page.goto(getServerUrl() + "/");
+    const body = await page.textContent("body");
+    // Playwright seems to await the HTML stream
+    expect(body).not.toContain(loading);
+    expect(body).toContain(content);
+    await testCounter();
+  });
+}
+
+function getTitle(html: string) {
+  const title = html.match(/<title>(.*?)<\/title>/i)?.[1];
+  return title;
+}
+
+async function testCounter() {
+  // autoRetry() for awaiting client-side code loading & executing
+  await autoRetry(
+    async () => {
+      expect(await page.textContent("button")).toBe("Counter 0");
+      await page.click("button");
+      expect(await page.textContent("button")).toContain("Counter 1");
+    },
+    { timeout: 5 * 1000 },
+  );
+}
+
+async function fetchAsBot(pathname: string) {
+  return await fetchHtml(pathname, "curl/8.5.0");
+}
+async function fetchAsUser(pathname: string) {
+  return await fetchHtml(pathname, "chrome");
+}
+async function fetchHtml(pathname: string, userAgent: string) {
+  const response = await fetch(getServerUrl() + pathname, { headers: { ["User-Agent"]: userAgent } });
+  const html = await response.text();
+  return html;
+}

--- a/examples/solid-query/package.json
+++ b/examples/solid-query/package.json
@@ -9,7 +9,7 @@
     "@tanstack/solid-query": "5.52.2",
     "node-fetch": "^3.3.2",
     "solid-js": "^1.8.22",
-    "vike": "^0.4.191",
+    "vike": "^0.4.195",
     "vike-solid": "workspace:^",
     "vike-solid-query": "workspace:^"
   },

--- a/examples/solid-query/pages/+config.ts
+++ b/examples/solid-query/pages/+config.ts
@@ -8,6 +8,6 @@ export default {
 
   passToClient: ["routeParams"],
   stream: true,
-  injectScriptsAt: "STREAM",
+  injectScriptsAt: "HTML_STREAM",
   extends: [vikeSolid, vikeSolidQuery],
 } satisfies Config;

--- a/examples/solid-query/pages/index/Movies.tsx
+++ b/examples/solid-query/pages/index/Movies.tsx
@@ -17,7 +17,7 @@ export function Movies() {
   };
 
   return (
-    <QueryBoundary query={query} loadingFallback={<p>Loading movies ...</p>}>
+    <QueryBoundary query={query} loadingFallback={"Loading movies..."}>
       {(movies) => (
         <>
           <Config title={`${movies.length} Star Wars movies`} />

--- a/packages/vike-solid-query/package.json
+++ b/packages/vike-solid-query/package.json
@@ -13,7 +13,7 @@
   "peerDependencies": {
     "@tanstack/solid-query": ">=5.0.0",
     "solid-js": "^1.8.7",
-    "vike-solid": ">=0.7.3"
+    "vike-solid": ">=0.7.4"
   },
   "devDependencies": {
     "@brillout/release-me": "^0.4.0",
@@ -26,8 +26,8 @@
     "solid-js": "^1.8.22",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4",
-    "vike": "^0.4.193",
-    "vike-solid": "^0.7.3",
+    "vike": "^0.4.195",
+    "vike-solid": "^0.7.4",
     "vite": "5.4.2"
   },
   "exports": {

--- a/packages/vike-solid/+config.ts
+++ b/packages/vike-solid/+config.ts
@@ -6,7 +6,7 @@ import { ssrEffect } from "./integration/ssrEffect.js";
 const config = {
   name: "vike-solid",
   require: {
-    vike: ">=0.4.191",
+    vike: ">=0.4.195",
   },
 
   // https://vike.dev/onRenderHtml

--- a/packages/vike-solid/integration/onRenderHtml.tsx
+++ b/packages/vike-solid/integration/onRenderHtml.tsx
@@ -1,5 +1,5 @@
 // https://vike.dev/onRenderHtml
-import { generateHydrationScript, renderToStream, renderToString } from "solid-js/web";
+import { generateHydrationScript, renderToStream, renderToString, renderToStringAsync } from "solid-js/web";
 import { dangerouslySkipEscape, escapeInject, stampPipe } from "vike/server";
 import { getHeadSetting } from "./getHeadSetting.js";
 import { getPageElement } from "./getPageElement.js";
@@ -10,6 +10,7 @@ import type { PageContextInternal } from "../types/PageContext.js";
 import type { Head } from "../types/Config.js";
 import type { JSX } from "solid-js/jsx-runtime";
 import { isCallable } from "../utils/isCallable.js";
+import isBot from "isbot-fast";
 
 export { onRenderHtml };
 
@@ -18,7 +19,7 @@ type TPipe = Parameters<typeof stampPipe>[0];
 const onRenderHtml: OnRenderHtmlAsync = async (
   pageContext: PageContextServer & PageContextInternal,
 ): ReturnType<OnRenderHtmlAsync> => {
-  const pageHtml = getPageHtml(pageContext);
+  const pageHtml = await getPageHtml(pageContext);
 
   const headHtml = getHeadHtml(pageContext);
 
@@ -40,10 +41,18 @@ const onRenderHtml: OnRenderHtmlAsync = async (
     </html>`;
 };
 
-function getPageHtml(pageContext: PageContextServer & PageContextInternal) {
+async function getPageHtml(pageContext: PageContextServer & PageContextInternal) {
   let pageHtml: string | ReturnType<typeof dangerouslySkipEscape> | TPipe = "";
+  const userAgent: string | undefined =
+    pageContext.headers?.["user-agent"] ||
+    // TODO/eventually: remove old way of acccessing the User Agent header.
+    // @ts-ignore
+    pageContext.userAgent;
+
   if (pageContext.Page) {
-    if (!pageContext.config.stream) {
+    if (userAgent && isBot(userAgent)) {
+      pageHtml = dangerouslySkipEscape(await renderToStringAsync(() => getPageElement(pageContext)));
+    } else if (!pageContext.config.stream) {
       pageHtml = dangerouslySkipEscape(renderToString(() => getPageElement(pageContext)));
     } else if (pageContext.config.stream === "web") {
       pageHtml = renderToStream(() => getPageElement(pageContext), {

--- a/packages/vike-solid/package.json
+++ b/packages/vike-solid/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "solid-js": "^1.8.7",
-    "vike": ">=0.4.191",
+    "vike": ">=0.4.195",
     "vite": ">=5.0.0"
   },
   "devDependencies": {
@@ -35,7 +35,7 @@
     "solid-js": "^1.8.22",
     "tslib": "^2.7.0",
     "typescript": "^5.5.4",
-    "vike": "^0.4.193",
+    "vike": "^0.4.195",
     "vite": "^5.4.2"
   },
   "exports": {

--- a/packages/vike-solid/package.json
+++ b/packages/vike-solid/package.json
@@ -11,6 +11,7 @@
     "release:commit": "LANG=en_US release-me commit"
   },
   "dependencies": {
+    "isbot-fast": "^1.2.0",
     "vite-plugin-solid": "^2.10.2"
   },
   "peerDependencies": {

--- a/packages/vike-solid/types/Config.ts
+++ b/packages/vike-solid/types/Config.ts
@@ -186,3 +186,4 @@ export type ConfigFromHook = PickWithoutGetter<
 >;
 export type ConfigFromHookResolved = Omit<ConfigFromHook, ConfigsCumulative> &
   Pick<Vike.ConfigResolved, ConfigsCumulative>;
+export type Stream = { write: (v: string) => void };

--- a/packages/vike-solid/types/PageContext.ts
+++ b/packages/vike-solid/types/PageContext.ts
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js";
-import type { ConfigFromHookResolved } from "./Config";
+import type { ConfigFromHookResolved, Stream } from "./Config";
 
 // https://vike.dev/pageContext#typescript
 declare global {
@@ -15,4 +15,5 @@ declare global {
 export type PageContextInternal = {
   _configFromHook?: ConfigFromHookResolved;
   _headAlreadySet?: boolean;
+  _stream?: Stream;
 };

--- a/packages/vike-solid/types/isBot.d.ts
+++ b/packages/vike-solid/types/isBot.d.ts
@@ -1,0 +1,4 @@
+declare module "isbot-fast" {
+  function isBot(userAgent: string): boolean;
+  export = isBot;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.8.21
         version: 1.8.22
       vike:
-        specifier: ^0.4.191
-        version: 0.4.193(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
+        specifier: ^0.4.195
+        version: 0.4.195(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
       vike-solid:
         specifier: link:../../packages/vike-solid
         version: link:../../packages/vike-solid
@@ -55,8 +55,8 @@ importers:
         specifier: ^1.8.21
         version: 1.8.22
       vike:
-        specifier: ^0.4.191
-        version: 0.4.193(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
+        specifier: ^0.4.195
+        version: 0.4.195(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
       vike-solid:
         specifier: link:../../packages/vike-solid
         version: link:../../packages/vike-solid
@@ -77,8 +77,8 @@ importers:
         specifier: ^1.8.22
         version: 1.8.22
       vike:
-        specifier: ^0.4.191
-        version: 0.4.193(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
+        specifier: ^0.4.195
+        version: 0.4.195(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
       vike-solid:
         specifier: link:../../packages/vike-solid
         version: link:../../packages/vike-solid
@@ -148,8 +148,8 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
       vike:
-        specifier: ^0.4.193
-        version: 0.4.193(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
+        specifier: ^0.4.195
+        version: 0.4.195(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@22.4.0)(terser@5.31.6)
@@ -187,8 +187,8 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
       vike:
-        specifier: ^0.4.193
-        version: 0.4.193(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
+        specifier: ^0.4.195
+        version: 0.4.195(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
       vike-solid:
         specifier: link:../vike-solid
         version: link:../vike-solid
@@ -2601,8 +2601,8 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  vike@0.4.193:
-    resolution: {integrity: sha512-nrqSXfocmm10asmoYrczO9iO4aZZ9SNygbpDTn0emmOPUFxROW3MUd8XcuBWJh6QVUTN4KiZYZDZGBMgPfhdbg==}
+  vike@0.4.195:
+    resolution: {integrity: sha512-I8ltb12bSz6aU2Rf+lEzvVVvcKedTav+cnGYTsposfzg5GIVc9YPeUBV8zgg93jUosxgIG0UExMh7EGuR3gQeg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -5117,7 +5117,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vike@0.4.193(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6)):
+  vike@0.4.195(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6)):
     dependencies:
       '@brillout/import': 0.2.3
       '@brillout/json-serializer': 0.5.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
 
   packages/vike-solid:
     dependencies:
+      isbot-fast:
+        specifier: ^1.2.0
+        version: 1.2.0
       vite-plugin-solid:
         specifier: ^2.10.2
         version: 2.10.2(solid-js@1.8.22)(vite@5.4.2(@types/node@22.4.0)(terser@5.31.6))
@@ -1905,6 +1908,10 @@ packages:
   is-what@4.1.15:
     resolution: {integrity: sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==}
     engines: {node: '>=12.13'}
+
+  isbot-fast@1.2.0:
+    resolution: {integrity: sha512-twjuQzy2gKMDVfKGQyQqrx6Uy4opu/fiVUTTpdqtFsd7OQijIp5oXvb27n5EemYXaijh5fomndJt/SPRLsEdSg==}
+    engines: {node: '>=6.0.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -4489,6 +4496,8 @@ snapshots:
       text-extensions: 2.4.0
 
   is-what@4.1.15: {}
+
+  isbot-fast@1.2.0: {}
 
   isexe@2.0.0: {}
 


### PR DESCRIPTION
Hi @magne4000.

What’s included in this PR:

- [x] Added test to examples/solid-query
- [x] Added support for useConfig() with HTML streaming
- [x] Added support for checking crawlers/bots & integrated `renderToStringAsync()`

Please review the changes and provide feedback. Let me know if there are any issues or additional improvements needed.