### PR TITLE
chore(vike-solid-query): remove unused vike-solid peer dependency

### DIFF
--- a/packages/vike-solid-query/package.json
+++ b/packages/vike-solid-query/package.json
@@ -12,8 +12,7 @@
   },
   "peerDependencies": {
     "@tanstack/solid-query": ">=5.0.0",
-    "solid-js": "^1.8.7",
-    "vike-solid": "workspace:^"
+    "solid-js": "^1.8.7"
   },
   "devDependencies": {
     "@brillout/release-me": "^0.4.1",


### PR DESCRIPTION
`vike-solid-query` use only the dependencies `@tanstack/solid-query` and `solid-js` in [/packages/vike-solid-query/src/QueryBoundary.tsx](https://github.com/vikejs/vike-solid/blob/main/packages/vike-solid-query/src/QueryBoundary.tsx)

Related https://github.com/vikejs/vike-solid/issues/116#issuecomment-2350959643