### PR TITLE
fix #144: Nested layouts infinite recursive call. 

### DIFF
--- a/packages/vike-solid/integration/getPageElement.tsx
+++ b/packages/vike-solid/integration/getPageElement.tsx
@@ -28,12 +28,12 @@ function Wrapper(props: { children: JSX.Element }) {
         ...(pageContext.config.Layout || []),
         // Outer wrapping
         ...(pageContext.config.Wrapper || []),
-      ]),
+        ].reverse()),
     );
   });
 
   const renderWrappers = (i: number = 0) => {
-    let item = wrappers.at(-(i + 1));
+    let item = wrappers[i]; // Assumes reversed, and must access with `[i]` instead of `.at(i)` otherwise, wrapper's states are not persisted.
 
     if (!item) return props.children;
 

--- a/packages/vike-solid/integration/getPageElement.tsx
+++ b/packages/vike-solid/integration/getPageElement.tsx
@@ -46,7 +46,7 @@ function Wrapper(props: { children: JSX.Element }) {
     });
   };
 
-  return <>{renderWrappers()}</>;
+  return <>{renderWrappers(0)}</>;
 }
 
 function Page() {


### PR DESCRIPTION
Fixes https://github.com/vikejs/vike-solid/issues/144

TL;DR; These are the two issues fixed:

- [x] Infinite Recursion (Error: Maximum call stack size exceeded)
- [x] Layout states not persisting when navigating into new [+Layout.tsx, +Layout.tsx, +Layout.tsx]