### PR TITLE
fix #156: Removed early return for useConfig so applyHead can be set on ssr=false.

### DIFF
--- a/packages/vike-solid/hooks/useConfig/useConfig-client.ts
+++ b/packages/vike-solid/hooks/useConfig/useConfig-client.ts
@@ -10,20 +10,20 @@ import { applyHeadSettings } from "../../integration/applyHeadSettings.jsx";
 function useConfig(): (config: ConfigFromHook) => void {
   // Vike hook
   let pageContext = getPageContext() as PageContext & PageContextInternal;
-  if (pageContext) return (config: ConfigFromHook) => setPageContextConfigFromHook(config, pageContext);
 
   // Component
-  pageContext = usePageContext();
+  if (!pageContext) pageContext = usePageContext() as PageContext & PageContextInternal;;
   return (config: ConfigFromHook) => {
     if (!("_headAlreadySet" in pageContext)) {
       setPageContextConfigFromHook(config, pageContext);
     } else {
-      applyHead(config);
+      if (typeof window !== 'undefined') applyHead(config);
     }
   };
 }
 
 function setPageContextConfigFromHook(config: ConfigFromHook, pageContext: PageContextInternal) {
+  console.log("setting page context config from hook.", config)
   pageContext._configFromHook ??= {};
   Object.assign(pageContext._configFromHook, config);
 }

--- a/packages/vike-solid/hooks/useConfig/useConfig-client.ts
+++ b/packages/vike-solid/hooks/useConfig/useConfig-client.ts
@@ -23,7 +23,6 @@ function useConfig(): (config: ConfigFromHook) => void {
 }
 
 function setPageContextConfigFromHook(config: ConfigFromHook, pageContext: PageContextInternal) {
-  console.log("setting page context config from hook.", config)
   pageContext._configFromHook ??= {};
   Object.assign(pageContext._configFromHook, config);
 }


### PR DESCRIPTION
This fixes https://github.com/vikejs/vike-solid/issues/156.

The expected result is that the `title` and `lang` is set even during `ssr: false`.

## Before the fix.
I think the reason why `title` and `lang` were not set during `ssr: false` is because in SolidJS, generally every component/hook runs only once. So early returns are discouraged because you will always get the first returned thing as it never re-runs the whole function.

Considering that, on the initial render on the client-side, `let pageContext = getPageContext() as PageContext & PageContextInternal;` exists so the function returned by the hook everytime is `() => setPageContextConfigFromHook(config, pageContext);` (which does not call `applyHead`).

`applyHead` is what sets the `title` and `lang`.

## The fix

Here, the returned function from the hook is always the same function which I think fixes the problem.
Also, unlike React, SolidJS can have "hooks" anywhere like inside an if statement, inside another hook's callback, etc. That's why you can see I'm using `usePageContext()` even inside an if statement.