### PR TITLE
fix: preserve client-side useConfig() settings in server-side pageContext (vikejs/vike-vue#233)

### DIFF
--- a/examples/full/.testRun.ts
+++ b/examples/full/.testRun.ts
@@ -181,6 +181,22 @@ function testUseConfig() {
     await page.goto(getServerUrl() + "/images");
     await testCounter();
   });
+  // The <title> set via useConfig() inside a server-side +data() hook should be applied upon
+  // client-side navigation (and persist in prerendered `*.pageContext.json` files).
+  // https://github.com/vikejs/vike-vue/issues/233
+  test("useConfig() in +data() upon client-side navigation", async () => {
+    await page.goto(getServerUrl() + "/");
+    expect(await page.title()).toBe("My Vike + Solid App");
+    await testCounter();
+    await page.click('a:has-text("Data Fetching")');
+    await ensureWasClientSideRouted("/pages/index");
+    // The movie page sets its <title> via useConfig({ title }) inside its server-side +data() hook.
+    await page.click('a:has-text("Return of the Jedi")');
+    await autoRetry(async () => {
+      expect(await page.title()).toBe("Return of the Jedi");
+    });
+    await ensureWasClientSideRouted("/pages/index");
+  });
 }
 
 function getTitle(html: string) {

--- a/packages/vike-solid/hooks/useConfig/configsClientSide.ts
+++ b/packages/vike-solid/hooks/useConfig/configsClientSide.ts
@@ -1,0 +1,2 @@
+// Settings the client-side applies upon navigation, see applyHeadSettings(). The others are HTML-only.
+export const configsClientSide = ["title", "lang"] as const;

--- a/packages/vike-solid/hooks/useConfig/useConfig-server.ts
+++ b/packages/vike-solid/hooks/useConfig/useConfig-server.ts
@@ -7,6 +7,7 @@ import { getPageContext } from "vike/getPageContext";
 import { objectKeys } from "../../utils/objectKeys.js";
 import { includes } from "../../utils/includes.js";
 import { configsCumulative } from "./configsCumulative.js";
+import { configsClientSide } from "./configsClientSide.js";
 
 /**
  * Set configurations inside components and Vike hooks.
@@ -30,12 +31,11 @@ function useConfig(): (config: ConfigFromHook) => void {
   };
 }
 
-const configsClientSide = ["title"];
 function setPageContextConfigFromHook(config: ConfigFromHook, pageContext: PageContext & PageContextInternal) {
   pageContext._configFromHook ??= {};
   objectKeys(config).forEach((configName) => {
     // Skip HTML only configs which the client-side doesn't need, saving KBs sent to the client as well as avoiding serialization errors.
-    if (pageContext.isClientSideNavigation && !configsClientSide.includes(configName)) return;
+    if (pageContext.isClientSideNavigation && !includes(configsClientSide, configName)) return;
 
     if (!includes(configsCumulative, configName)) {
       // Overridable config

--- a/packages/vike-solid/integration/onRenderHtml.tsx
+++ b/packages/vike-solid/integration/onRenderHtml.tsx
@@ -15,6 +15,9 @@ import { isObject } from "../utils/isObject.js";
 import { isType } from "../utils/isType.js";
 import { getHeadSetting } from "./getHeadSetting.js";
 import { getPageElement } from "./getPageElement.js";
+import { configsClientSide } from "../hooks/useConfig/configsClientSide.js";
+import { objectKeys } from "../utils/objectKeys.js";
+import { includes } from "../utils/includes.js";
 
 export { onRenderHtml };
 
@@ -29,8 +32,9 @@ const onRenderHtml: OnRenderHtmlAsync = async (
 
   const { htmlAttributesString, bodyAttributesString } = getTagAttributes(pageContext);
 
-  // Not needed on the client-side, thus we remove it to save KBs sent to the client
-  delete pageContext._configFromHook;
+  // Keep only what the client-side applies upon navigation, and remove the rest (HTML-only and/or
+  // non-serializable values such as <Head> components). https://github.com/vikejs/vike-vue/issues/233
+  removeServerOnlyConfigFromHook(pageContext);
 
   return escapeInject`<!DOCTYPE html>
     <html${dangerouslySkipEscape(htmlAttributesString)}>
@@ -44,6 +48,16 @@ const onRenderHtml: OnRenderHtmlAsync = async (
       </body>
     </html>`;
 };
+
+function removeServerOnlyConfigFromHook(pageContext: PageContextInternal) {
+  const configFromHook = pageContext._configFromHook;
+  if (!configFromHook) return;
+  objectKeys(configFromHook).forEach((configName) => {
+    if (!includes(configsClientSide, configName)) delete configFromHook[configName];
+  });
+  // Remove it altogether if there isn't anything left, saving KBs sent to the client
+  if (objectKeys(configFromHook).length === 0) delete pageContext._configFromHook;
+}
 
 async function getPageHtml(pageContext: PageContextServer & PageContextInternal) {
   let pageHtml: string | ReturnType<typeof dangerouslySkipEscape> | TPipe = "";


### PR DESCRIPTION
Port of vikejs/vike-vue#234 (which fixed vikejs/vike-vue#233) to **vike-solid**, which has the identical bug (here the internal field is named `_configFromHook`).

## Problem

When a prerendered app sets `title` via `useConfig({ title })` inside a server `+data()` hook, the initial HTML has the correct `<title>`, but `document.title` is **not** updated upon client-side navigation on statically deployed apps. A page refresh fixes it.

### Root cause

Settings passed via `useConfig()` are stored in `pageContext._configFromHook` (part of `passToClient`). But `onRenderHtml()` deleted the **entire** `_configFromHook` object before the prerendered `*.pageContext.json` was serialized:

```ts
// Not needed on the client-side, thus we remove it to save KBs sent to the client
delete pageContext._configFromHook;
```

For non-prerendered apps this is harmless: client-side navigation re-runs `+data()` on the server (with `isClientSideNavigation`), repopulating `_configFromHook` in a fresh `pageContext.json` that never passes through `onRenderHtml()`. But for **prerendered** apps the `*.pageContext.json` files *are* produced from the render that `onRenderHtml()` mutated — so the `title` was stripped and lost on client navigation.

## Fix

Instead of deleting `_configFromHook` wholesale, keep only the settings the client-side actually applies upon navigation — `title` and `lang` (see `applyHeadSettings()`) — and drop everything else (HTML-only and/or non-serializable values such as `<Head>` components). When nothing client-side remains, `_configFromHook` is dropped entirely (preserving the original "don't ship an empty object" behavior):

```ts
function removeServerOnlyConfigFromHook(pageContext: PageContextInternal) {
  const configFromHook = pageContext._configFromHook;
  if (!configFromHook) return;
  objectKeys(configFromHook).forEach((configName) => {
    if (!includes(configsClientSide, configName)) delete configFromHook[configName];
  });
  // Remove it altogether if there isn't anything left, saving KBs sent to the client
  if (objectKeys(configFromHook).length === 0) delete pageContext._configFromHook;
}
```

The client-side settings list is now a single shared `configsClientSide` constant (`["title", "lang"]`), reused by both `onRenderHtml()` and `useConfig()` (server). Previously the server hook hard-coded `["title"]`; it now also includes `lang`, which `applyHeadSettings()` applies on the client too.

### On the client, `_configFromHook` is only read for `title`/`lang`

- `getHeadSetting()` (used by `onRenderClient` → `applyHead`) reads only `title` and `lang`.
- The `Head` entry is read in the head rendering **only** server-side.

So narrowing the client payload to `title`/`lang` is safe.

## Testing

- `tsc --noEmit` and biome pass.
- Added an e2e test to the `full` example (`useConfig() in +data() upon client-side navigation`) that navigates client-side to a page whose `<title>` is set via `useConfig({ title })` in its server `+data()` hook, and asserts `document.title` updates. The dev e2e suite passes locally (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvFjBdBmQ2wVMBHwHmouky)_